### PR TITLE
Avoid console.log error `Cannot read properties of undefined (reading 'previousAction')` in zoom / fit actions

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1064](https://github.com/InditexTech/weavejs/issues/1064) Fix unnecessary console.log type errors / undefined errors in SDK
 - [#1065](https://github.com/InditexTech/weavejs/issues/1065) Fix error cannot set properties of undefined (setting 'dragStatus'), avoid console.log imprint
+- [#1067](https://github.com/InditexTech/weavejs/issues/1067) Avoid console.log error `Cannot read properties of undefined (reading 'previousAction')` in zoom / fit actions
 
 ## [3.9.1] - 2026-05-13
 

--- a/code/packages/sdk/src/actions/fit-to-screen-tool/fit-to-screen-tool.ts
+++ b/code/packages/sdk/src/actions/fit-to-screen-tool/fit-to-screen-tool.ts
@@ -50,7 +50,7 @@ export class WeaveFitToScreenToolAction extends WeaveAction {
       });
     }
 
-    this.previousAction = params.previousAction;
+    this.previousAction = params?.previousAction;
     this.cancelAction = cancelAction;
 
     this.cancelAction();
@@ -59,7 +59,7 @@ export class WeaveFitToScreenToolAction extends WeaveAction {
   cleanup(): void {
     const stage = this.instance.getStage();
 
-    if (this.previousAction !== undefined) {
+    if (this.previousAction) {
       this.instance.triggerAction(this.previousAction);
     }
 

--- a/code/packages/sdk/src/actions/fit-to-selection-tool/fit-to-selection-tool.ts
+++ b/code/packages/sdk/src/actions/fit-to-selection-tool/fit-to-selection-tool.ts
@@ -64,7 +64,7 @@ export class WeaveFitToSelectionToolAction extends WeaveAction {
       overrideZoom: params?.overrideZoom ?? true,
     });
 
-    this.previousAction = params.previousAction;
+    this.previousAction = params?.previousAction;
     this.cancelAction = cancelAction;
 
     this.cancelAction();
@@ -73,7 +73,7 @@ export class WeaveFitToSelectionToolAction extends WeaveAction {
   cleanup(): void {
     const stage = this.instance.getStage();
 
-    if (this.previousAction !== undefined) {
+    if (this.previousAction) {
       this.instance.triggerAction(this.previousAction);
     }
 

--- a/code/packages/sdk/src/actions/zoom-in-tool/zoom-in-tool.ts
+++ b/code/packages/sdk/src/actions/zoom-in-tool/zoom-in-tool.ts
@@ -47,7 +47,7 @@ export class WeaveZoomInToolAction extends WeaveAction {
 
     stageZoomPlugin.zoomIn();
 
-    this.previousAction = params.previousAction;
+    this.previousAction = params?.previousAction;
     this.cancelAction = cancelAction;
 
     this.cancelAction();
@@ -56,7 +56,7 @@ export class WeaveZoomInToolAction extends WeaveAction {
   cleanup(): void {
     const stage = this.instance.getStage();
 
-    if (this.previousAction !== undefined) {
+    if (this.previousAction) {
       this.instance.triggerAction(this.previousAction);
     }
 

--- a/code/packages/sdk/src/actions/zoom-out-tool/zoom-out-tool.ts
+++ b/code/packages/sdk/src/actions/zoom-out-tool/zoom-out-tool.ts
@@ -45,7 +45,7 @@ export class WeaveZoomOutToolAction extends WeaveAction {
 
     stageZoomPlugin.zoomOut();
 
-    this.previousAction = params.previousAction;
+    this.previousAction = params?.previousAction;
     this.cancelAction = cancelAction;
 
     this.cancelAction();
@@ -54,7 +54,7 @@ export class WeaveZoomOutToolAction extends WeaveAction {
   cleanup(): void {
     const stage = this.instance.getStage();
 
-    if (this.previousAction !== undefined) {
+    if (this.previousAction) {
       this.instance.triggerAction(this.previousAction);
     }
 

--- a/code/packages/sdk/src/plugins/copy-paste-nodes/copy-paste-nodes.ts
+++ b/code/packages/sdk/src/plugins/copy-paste-nodes/copy-paste-nodes.ts
@@ -39,6 +39,9 @@ import {
 import type { WeaveStageGridPlugin } from '../stage-grid/stage-grid';
 import type Konva from 'konva';
 import type { Weave } from '@/weave';
+import { FIT_TO_SELECTION_TOOL_ACTION_NAME } from '@/actions/fit-to-selection-tool/constants';
+import { SELECTION_TOOL_ACTION_NAME } from '@/actions/selection-tool/constants';
+import type { WeaveFitToSelectionToolActionParams } from '@/actions/fit-to-selection-tool/types';
 
 export class WeaveCopyPasteNodesPlugin extends WeavePlugin {
   protected state!: WeaveCopyPasteNodesPluginState;
@@ -398,8 +401,11 @@ export class WeaveCopyPasteNodesPlugin extends WeavePlugin {
           const nodesSelectionPlugin = this.getNodesSelectionPlugin();
           nodesSelectionPlugin?.setSelectedNodes(realNodes);
 
-          this.instance?.triggerAction('fitToSelectionTool', {
-            previousAction: 'selectionTool',
+          this.instance?.triggerAction<
+            WeaveFitToSelectionToolActionParams,
+            void
+          >(FIT_TO_SELECTION_TOOL_ACTION_NAME, {
+            previousAction: SELECTION_TOOL_ACTION_NAME,
             smartZoom: true,
           });
 

--- a/docs/content/docs/main/changelog/3.x/3.9.2.mdx
+++ b/docs/content/docs/main/changelog/3.x/3.9.2.mdx
@@ -11,3 +11,4 @@ description: Minor bugfixes to avoid console.log errors output
 
 - [#1064](https://github.com/InditexTech/weavejs/issues/1064) Fix unnecessary console.log type errors / undefined errors in SDK
 - [#1065](https://github.com/InditexTech/weavejs/issues/1065) Fix error cannot set properties of undefined (setting 'dragStatus'), avoid console.log imprint
+- [#1067](https://github.com/InditexTech/weavejs/issues/1067) Avoid console.log error `Cannot read properties of undefined (reading 'previousAction')` in zoom / fit actions


### PR DESCRIPTION
Closes #1067