### PR TITLE
docs(openspec): init spec-driven workflow and consumer test strategy

### DIFF
--- a/openspec/changes/establish-consumer-test-strategy/.openspec.yaml
+++ b/openspec/changes/establish-consumer-test-strategy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-17

--- a/openspec/changes/establish-consumer-test-strategy/design.md
+++ b/openspec/changes/establish-consumer-test-strategy/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Weave.js is an Nx/npm-workspace monorepo whose publishable SDK, React, renderer, store, and generator packages are consumed outside the workspace. Existing package tests exercise package behavior, but workspace resolution does not prove packed artifact contents, `exports`, type declarations, peer dependency metadata, or browser/server boundaries. The repository has package verification workflows but no minimal in-repository consumer applications or end-to-end collaboration contract.
+
+The existing generated WebSocket applications already use the Weave React/SDK and WebSocket-store APIs, but they are showcase-sized Next.js and Express templates with product-facing features, broad node registration, and ancillary dependencies. They are a source for supported integration code, not a stable compatibility gate. The strategy must preserve independent external showcase applications as examples rather than compatibility gates and test WebSocket collaboration without live cloud dependencies; Azure Web PubSub remains covered by controlled unit and contract tests.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Validate supported published-package entry points from isolated consumers that install local npm tarballs.
+- Establish the small, focused frontend and backend consumers as the first implementation phase and canonical supported integration shape.
+- Exercise a supported rectangle lifecycle: create, remote render, update, delete, and reconnect.
+- Exercise semantic two-client WebSocket synchronization in a real browser.
+- Validate generator output both structurally and as independently built projects.
+- Run the right distribution checks on relevant pull requests and a complete configuration matrix on a schedule.
+- Prove that node registration and cross-cutting plugin extension points generalize beyond a single node type, and that concurrent conflicting edits converge deterministically.
+
+**Non-Goals:**
+
+- Recreate external showcase products, their UI, databases, authentication, AI, storage, or cloud integrations.
+- Make canvas screenshots the primary integration correctness signal.
+- Add a live Azure Web PubSub environment or cloud credentials to CI.
+- Replace detailed package unit tests with consumer tests.
+- Validate package tarballs against a registry publication.
+- Measure or gate on performance, load, or many-concurrent-client scalability; this strategy validates correctness of the consumer contract, not performance characteristics.
+- Remove, replace, or deprecate any existing generator template or scaffolding option; canonical starters are additive, and every currently supported combination (Next.js + WebSocket, Next.js + Azure Web PubSub, Express + WebSocket, Express + Azure Web PubSub) remains available and unchanged.
+
+## Decisions
+
+### Test packed artifacts in isolated temporary consumers
+
+The test harness will build the selected publishable packages, create tarballs with `npm pack`, and install those tarballs into temporary projects that do not reference the workspace. The consumers will type-check and build explicit browser imports and `@inditextech/weave-sdk/server`.
+
+Tarballs are selected over workspace links because links can resolve source files or hoisted dependencies that would not be present for npm consumers. Registry publication was considered but rejected because it adds release coupling and network variability without increasing coverage of the package manifest and contents.
+
+### Use two small, non-published reference applications
+
+Before any tarball or browser harness is added, `code/apps/reference-frontend` will be created as a Vite + React app and `code/apps/reference-backend` as an Express + WebSocket service. They will extract the smallest usable slice of the current WebSocket generators: documented Weave configuration, the required node registration, action/plugin setup, and the WebSocket store/server lifecycle. The frontend will expose a stable, semantic test surface for creating one rectangle, updating it, and deleting it; the backend will host the corresponding room lifecycle. The contract will also cover remote rendering and reconnecting to current state. Standalone store use remains a build/smoke concern rather than part of the two-client collaboration flow.
+
+One combined application was considered but rejected because failures would conflate browser and server responsibilities. External showcase repositories were considered as consumers but rejected because product-specific integrations make them unstable compatibility gates.
+
+To prove the contract generalizes rather than only exercising one hardcoded shape, the frontend will also register one additional, structurally distinct node type and enable the undo/redo action as a minimal cross-cutting plugin. This stays a genericity smoke check, not a node-type or plugin coverage matrix: a full matrix of node types, actions, and plugins remains the responsibility of package-level unit tests.
+
+### Test collaboration through Playwright semantic assertions
+
+The integration harness will start both reference applications and use real Chromium with two independent browser contexts. It will assert shared model and rendered UI state while clients create, update, delete, reconnect, and converge through the WebSocket service.
+
+This is more representative than mocked transport or one-page tests. Pixel screenshots are optional diagnostics only because rendering differences make them a weak primary signal. The browser lane will test the WebSocket happy path; detailed action/plugin edge cases stay in Vitest unit coverage.
+
+In addition to the sequential happy path, the harness will run one concurrent-edit scenario: both browser clients change the same shared attribute without waiting on each other's acknowledgment, and the test asserts that both clients converge on the same deterministic result once the CRDT merge settles. This is the scenario that actually exercises Yjs's conflict-resolution behavior rather than only sequential turn-taking, and it stays scoped to the existing rectangle contract rather than expanding into a general conflict-matrix.
+
+The PR-gating lane runs against Chromium only, for speed. The nightly matrix additionally runs the same collaboration suite against Firefox to catch browser-engine-specific regressions without slowing the PR feedback loop; WebKit is not added at this time.
+
+### Share canonical starter application source
+
+The reference consumer source established in the first phase will be the canonical starter shape. Generators will add a new Vite + React frontend option and a new minimal Express + WebSocket backend option that share source with the reference consumers, exposed as additional choices alongside every existing template. No existing generator template is replaced or removed: the current Next.js + WebSocket, Next.js + Azure Web PubSub, Express + WebSocket, and Express + Azure Web PubSub combinations all remain available with unchanged behavior; they are simply not covered by the new canonical-source and generated-project validation added in this change. Generators will retain only generation-specific concerns for the new canonical options: project naming, dependency versions, package-manager installation, README generation, and prompts. Test-only harness code stays outside generated output.
+
+### Split PR, nightly, and release validation by risk
+
+Relevant pull requests will run affected lint, type-check, build, and unit work. Changes to publishable packages, package metadata, generators, or reference consumers will additionally run tarball smoke validation and the WebSocket collaboration scenario as blocking gates. A nightly matrix will cover every supported standalone/WebSocket configuration, and release candidates will run that full matrix before publication.
+
+Running the full matrix for every pull request was rejected due to unnecessary latency. Relying on manual release checks was rejected because package-boundary regressions need an earlier, enforceable signal. CI will cache npm dependencies and build artifacts, and path selection will avoid unrelated runs.
+
+## Risks / Trade-offs
+
+- [Temporary consumer setup may be slow or flaky] -> Cache installs and build artifacts, use deterministic local tarball paths, and clean test directories.
+- [Browser tests can be timing-sensitive] -> Use readiness checks and state-based Playwright assertions rather than fixed delays.
+- [Shared starter source can complicate generator substitutions] -> Isolate substitutions to generator-owned metadata and test generated output trees without installing dependencies.
+- [A large nightly configuration matrix increases maintenance] -> Centralize transport/configuration definitions in the test harness and make each configuration independently addressable.
+- [Tarball tests can expose peer-dependency duplication] -> Install declared peers deliberately and use the supported local Konva/Yjs paths only where the consumer contract requires them.
+- [Concurrent-edit assertions can be timing-sensitive or flaky] -> Assert on converged state after both clients' operations settle rather than on intermediate ordering, and avoid asserting a specific merge winner where the CRDT contract does not guarantee one.
+- [Existing Azure Web PubSub generator templates fall outside the standalone/WebSocket validation matrix and are not covered by the new generated-project build validation] -> Accepted for now; they remain available and unchanged, just untested by this change's new checks.
+
+## Migration Plan
+
+1. Extract and build the minimal canonical reference consumers, including the rectangle create, update, delete, remote-render, and reconnect contract, without changing public runtime behavior.
+2. Add pack/install helpers and validate the reference consumers against packed artifacts.
+3. Add the collaboration checks as path-selected PR gates, initially observing their duration and stability.
+4. Add the canonical Vite + React frontend and minimal Express + WebSocket backend as new generator options, then add generated-project validation covering the existing and new supported starters.
+5. Add the nightly configuration matrix and make the new gates release-blocking; rollback a failing rollout by disabling the new workflow job while preserving existing unit/package checks.
+
+## Open Questions
+
+None. The implementation will define the exact package and transport configuration matrix from the publishable package manifests and documented generator options.

--- a/openspec/changes/establish-consumer-test-strategy/proposal.md
+++ b/openspec/changes/establish-consumer-test-strategy/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The current test suite proves package internals but does not prove that the artifacts published to npm install and work for the supported browser and backend consumer contracts. This can allow broken exports, omitted files, peer-dependency issues, starter drift, and basic WebSocket collaboration regressions to reach a release.
+
+## What Changes
+
+- First extract a minimal, canonical Vite + React and Express + WebSocket integration shape from the existing WebSocket starters into non-published reference consumers under `code/apps/`.
+- Include supported rectangle create, update, delete, render, and reconnect behavior in that canonical shape as the initial consumer happy-path contract.
+- Add npm-tarball package-boundary validation in isolated consumer projects for publishable packages and browser/server entry points.
+- Add a Playwright scenario that verifies two browser clients can create, synchronize, update, delete, reconnect, and render shared WebSocket state.
+- Extend the reference contract with a second, distinct node type and a minimal cross-cutting plugin (undo/redo) to prove the node-registration and plugin mechanisms generalize beyond a single hardcoded rectangle.
+- Add a concurrent-edit scenario in which two clients change the same shared attribute without waiting on each other, asserting deterministic convergence through the CRDT merge.
+- Add generator unit coverage and generated-project build validation using packed local Weave.js artifacts.
+- Add the canonical Vite + React frontend and minimal Express + WebSocket backend as new, additional generator template options, sharing source with the reference consumers; keep every existing generator template (including both Next.js and both Azure Web PubSub combinations) available and unchanged.
+- Add path-selected PR gates and nightly/release matrices for the new distribution and integration validation, including a Firefox browser-engine lane in the nightly matrix alongside the Chromium PR lane.
+
+## Capabilities
+
+### New Capabilities
+
+- `package-tarball-validation`: Validate publishable artifacts as packages installed from npm tarballs, including their declared public entry points.
+- `reference-consumer-integration`: Provide minimal browser and backend consumers and verify real two-client WebSocket collaboration.
+- `generated-starter-validation`: Verify generator output against packed artifacts and maintain canonical starter source shared with reference consumers.
+- `distribution-test-automation`: Select, schedule, cache, and enforce distribution-level validation in CI.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: package build and pack targets; `code/apps/`; SDK, React, WebSocket-store, and generator packages; test helpers; and GitHub Actions workflows.
+- Affected tooling: npm pack/install, Vitest, Vite, Express, WebSockets, and Playwright/Chromium.
+- Affected release process: changes to publishable packages, package metadata, generators, or reference consumers gain blocking tarball-consumer and collaboration gates; no live Azure credentials or cloud services are required.

--- a/openspec/changes/establish-consumer-test-strategy/specs/distribution-test-automation/spec.md
+++ b/openspec/changes/establish-consumer-test-strategy/specs/distribution-test-automation/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Relevant pull requests run required distribution validation
+The CI system SHALL run affected lint, type-check, build, and unit tests for every relevant pull request. A pull request that changes a publishable package, package metadata, a generator, or a reference consumer MUST additionally run tarball-consumer validation and the WebSocket collaboration scenario as blocking checks.
+
+#### Scenario: A publishable package changes
+- **WHEN** a pull request changes a publishable package or its package metadata
+- **THEN** CI runs the tarball-consumer and WebSocket collaboration checks and blocks the pull request if either fails
+
+#### Scenario: An unrelated documentation-only change occurs
+- **WHEN** a pull request does not modify a selected code or distribution-validation path
+- **THEN** CI does not run the distribution-validation lane solely because of that change
+
+### Requirement: Complete transport coverage runs before releases
+The CI system SHALL run a nightly matrix covering every supported standalone and WebSocket configuration and SHALL run the same full matrix for release candidates before publication. The nightly matrix MUST also run the WebSocket collaboration scenario against Firefox in addition to Chromium; the pull-request collaboration gate remains Chromium-only for speed.
+
+#### Scenario: Nightly validation runs the transport matrix
+- **WHEN** the scheduled nightly workflow starts
+- **THEN** it executes the complete supported standalone and WebSocket configuration matrix
+
+#### Scenario: A release candidate is prepared
+- **WHEN** a release candidate enters publication validation
+- **THEN** the complete nightly transport matrix passes before publication proceeds
+
+#### Scenario: Nightly validation runs the collaboration scenario on a second browser engine
+- **WHEN** the scheduled nightly workflow runs the WebSocket collaboration scenario
+- **THEN** it executes that scenario against both Chromium and Firefox
+
+### Requirement: Cloud transports remain independent of CI integration infrastructure
+Azure Web PubSub validation SHALL use unit and contract tests with controlled mocks. The normal tarball-consumer, reference-consumer, and collaboration lanes MUST NOT require Azure credentials or a live external cloud service.
+
+#### Scenario: A standard pull request runs distribution validation
+- **WHEN** CI runs the normal distribution-validation lane
+- **THEN** the lane completes without requesting cloud credentials or contacting a live Azure service
+
+### Requirement: Distribution validation is efficient and diagnosable
+The CI system SHALL select distribution jobs by relevant paths and cache package-manager dependencies and reusable build artifacts. A failed distribution job MUST identify the failed validation stage and affected consumer or configuration.
+
+#### Scenario: A cached relevant validation run starts
+- **WHEN** a relevant pull request reruns without dependency or artifact-input changes
+- **THEN** CI reuses eligible dependency and build caches while still executing the required validation
+
+#### Scenario: A matrix configuration fails
+- **WHEN** a tarball consumer or transport configuration fails
+- **THEN** CI identifies the failed validation stage and consumer or configuration in the job result

--- a/openspec/changes/establish-consumer-test-strategy/specs/generated-starter-validation/spec.md
+++ b/openspec/changes/establish-consumer-test-strategy/specs/generated-starter-validation/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Generator behavior is directly tested without dependency installation
+Each frontend and backend generator SHALL have direct tests that run generation with dependency installation disabled. The tests MUST validate the output tree, renamed dotfiles, generated package manifest, selected transport configuration, and invalid-input error handling.
+
+#### Scenario: Generator creates a selected transport starter
+- **WHEN** a generator is run with a supported transport and dependency installation disabled
+- **THEN** the output contains the expected application files, renamed dotfiles, manifest, and selected transport configuration
+
+#### Scenario: Generator receives invalid input
+- **WHEN** a generator receives unsupported or invalid generation input
+- **THEN** it reports an error and does not report a successfully generated starter
+
+### Requirement: Generated starters build against packed artifacts
+The validation system SHALL generate every supported standalone and WebSocket frontend and backend starter, existing and newly-added canonical, into a temporary directory, install locally packed Weave.js artifacts, type-check the project, and complete its production build. Azure Web PubSub generator templates are outside this validation's scope.
+
+#### Scenario: Generated frontend starter builds
+- **WHEN** a supported frontend starter is generated and installed with packed artifacts
+- **THEN** its type-check and production build complete successfully
+
+#### Scenario: Generated backend starter builds
+- **WHEN** a supported backend starter is generated and installed with packed artifacts
+- **THEN** its type-check and production build complete successfully
+
+### Requirement: Canonical starter source is added without removing existing templates
+The generators SHALL add a new Vite + React frontend starter option and a new minimal Express + WebSocket backend starter option that share source with the reference consumers established for this strategy. Every existing generator template SHALL remain available with unchanged behavior; no existing template is replaced, migrated, or removed. Application source shared between reference consumers and the new canonical starters MUST have one canonical implementation; generators MUST limit their unique logic for these options to naming, dependency versions, installation, README generation, prompts, and other generation-specific metadata.
+
+#### Scenario: A new canonical starter option is added
+- **WHEN** the canonical Vite + React frontend or minimal Express + WebSocket backend option is added to a generator
+- **THEN** the generator offers it as an additional choice using the reference consumer's established minimal rectangle lifecycle and WebSocket integration shape, without altering any existing template's output or behavior
+
+#### Scenario: A canonical starter behavior changes
+- **WHEN** application source shared by an established reference consumer and a new canonical generated starter changes
+- **THEN** the reference consumer and generated-project validation both exercise the changed canonical behavior

--- a/openspec/changes/establish-consumer-test-strategy/specs/package-tarball-validation/spec.md
+++ b/openspec/changes/establish-consumer-test-strategy/specs/package-tarball-validation/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Publishable packages are validated as packed dependencies
+The validation system SHALL build every publishable package selected for distribution validation, create an npm tarball for each selected package, and install the tarballs into an isolated temporary consumer directory. The consumer directory MUST NOT use npm workspace links, file references to package source, or a registry-published Weave.js artifact.
+
+#### Scenario: Packed package installs in an isolated consumer
+- **WHEN** a selected publishable package is validated
+- **THEN** its consumer installs the locally packed tarball and does not resolve that package from the monorepo workspace
+
+#### Scenario: Packed package omits a required published file
+- **WHEN** a consumer imports a file or declaration omitted from a selected package tarball
+- **THEN** the distribution validation fails before the change is eligible for release
+
+### Requirement: Public browser and server entry points compile for consumers
+The validation system SHALL type-check and production-build consumer projects that explicitly import supported browser entry points and `@inditextech/weave-sdk/server`. The validation MUST detect invalid exports, missing declarations, browser/server boundary leaks, unresolved transitive dependencies, and invalid peer dependency metadata.
+
+#### Scenario: Browser consumer imports a supported package entry point
+- **WHEN** an isolated browser consumer imports a supported browser entry point from a packed package
+- **THEN** its type-check and production build complete successfully
+
+#### Scenario: Backend consumer imports the SDK server entry point
+- **WHEN** an isolated backend consumer imports `@inditextech/weave-sdk/server` from a packed SDK tarball
+- **THEN** its type-check and production build complete successfully without importing browser-only code
+
+### Requirement: Tarball validation reports package-boundary failures
+The validation system SHALL fail the relevant distribution check when packing, installing, type-checking, or building a selected consumer fails.
+
+#### Scenario: A packed artifact has invalid dependency metadata
+- **WHEN** the isolated consumer cannot install or build because a packed artifact declares invalid dependency metadata
+- **THEN** the distribution check fails with the affected package and consumer identified

--- a/openspec/changes/establish-consumer-test-strategy/specs/reference-consumer-integration/spec.md
+++ b/openspec/changes/establish-consumer-test-strategy/specs/reference-consumer-integration/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Minimal reference consumers are established before integration harnesses
+The repository SHALL first establish non-published `code/apps/reference-frontend` and `code/apps/reference-backend` applications before adding tarball-consumer or browser collaboration harnesses. The frontend MUST use Vite + React and demonstrate documented node registration, action/plugin setup, state operations, standalone store use, and WebSocket client use. The backend MUST use Express + WebSockets and demonstrate the SDK server entry point and WebSocket server lifecycle.
+
+#### Scenario: Reference consumers establish the initial supported contract
+- **WHEN** the reference consumers are introduced
+- **THEN** they provide the canonical browser and backend integration shape before package-boundary and browser integration harnesses are implemented
+
+#### Scenario: A product-specific dependency is proposed for a reference app
+- **WHEN** a reference consumer is changed to add product UI, a database, authentication, AI, storage, or cloud-specific behavior
+- **THEN** the change is rejected because that behavior is outside the supported consumer contract
+
+### Requirement: Reference consumers expose a minimal valid canvas lifecycle
+The reference consumers SHALL support a rectangle as the initial shared canvas element. The frontend MUST provide stable semantic controls or test hooks to create, update, and delete that rectangle through supported Weave APIs; the backend MUST host its WebSocket room. The contract MUST include remote rendering and reconnecting to current document state.
+
+#### Scenario: A client creates and updates a rectangle
+- **WHEN** a connected client creates a rectangle and changes its supported attributes
+- **THEN** the initiating client and a second browser client render the same updated rectangle
+
+#### Scenario: A client deletes a rectangle
+- **WHEN** a connected client deletes the shared rectangle
+- **THEN** both browser clients converge on a document without that rectangle
+
+#### Scenario: A client reconnects to a rectangle document
+- **WHEN** a browser client reconnects after another client has created or updated the shared rectangle
+- **THEN** it receives and renders the current rectangle state
+
+### Requirement: WebSocket collaboration converges between browser clients
+The integration system SHALL start both reference consumers and use real Chromium in two independent browser contexts to exercise WebSocket collaboration. It MUST assert semantic shared-model and rendered UI state for connection, creation, update, deletion, convergence, and reconnection.
+
+#### Scenario: Two clients synchronize lifecycle changes
+- **WHEN** one connected browser client creates shared state, then a client updates and deletes it
+- **THEN** the other browser client receives and renders each change and both clients converge on the same state
+
+#### Scenario: A client reconnects after shared state changes
+- **WHEN** a browser client disconnects after another client has changed the document and then reconnects
+- **THEN** the reconnected client receives and renders the current document state
+
+#### Scenario: Two clients edit the same attribute concurrently
+- **WHEN** both browser clients change the same shared attribute without waiting on each other's acknowledgment
+- **THEN** both clients converge on the same deterministic state once the CRDT merge settles, without the test asserting a specific intermediate ordering
+
+### Requirement: Reference consumers demonstrate a second node type and a cross-cutting plugin
+The reference frontend SHALL register a second, structurally distinct node type beyond the rectangle and enable the undo/redo action, to demonstrate that node registration and plugin extension points generalize beyond a single hardcoded shape. This remains a genericity smoke check and MUST NOT expand into a full node-type or plugin coverage matrix; comprehensive node, action, and plugin coverage stays in package-level unit tests.
+
+#### Scenario: A second node type is registered and rendered
+- **WHEN** the reference frontend registers its second node type
+- **THEN** a client can create and render an instance of that node type alongside the existing rectangle contract
+
+#### Scenario: Undo/redo reverts and reapplies a shared change
+- **WHEN** a client performs a supported change and then triggers undo followed by redo
+- **THEN** the shared document reflects the reverted state after undo and the reapplied state after redo
+
+### Requirement: Reference consumers build from packed artifacts
+The reference frontend and backend SHALL type-check and complete production builds when installed with locally packed Weave.js artifacts.
+
+#### Scenario: Reference consumers are installed with packed artifacts
+- **WHEN** the reference frontend and backend are installed with locally packed Weave.js artifacts
+- **THEN** each application type-checks and completes a production build
+
+### Requirement: Browser integration assertions are behavior-based
+The collaboration test SHALL use state and UI assertions as its primary correctness signal and MUST NOT require canvas screenshot pixel comparisons to pass.
+
+#### Scenario: Canvas rendering varies without semantic regression
+- **WHEN** rendered pixels vary while the expected model and UI state are present in both browser contexts
+- **THEN** the collaboration scenario passes without a screenshot comparison

--- a/openspec/changes/establish-consumer-test-strategy/tasks.md
+++ b/openspec/changes/establish-consumer-test-strategy/tasks.md
@@ -1,0 +1,47 @@
+## 1. Canonical reference-app foundation
+
+- [ ] 1.1 Review the existing WebSocket generator templates and identify the minimal documented Weave configuration, node registration, action/plugin setup, and WebSocket room lifecycle required for a rectangle create, update, delete, remote-render, and reconnect flow.
+- [ ] 1.2 Add the non-published `code/apps/reference-frontend` Vite + React application by extracting only that minimal supported browser integration shape from the existing templates.
+- [ ] 1.3 Add the non-published `code/apps/reference-backend` Express + WebSocket application using the SDK server entry point and minimal WebSocket store/server lifecycle.
+- [ ] 1.4 Implement the initial shared rectangle contract: stable semantic controls or test hooks for creation, attribute update, deletion, rendered-state observation, and current-state reconnection.
+- [ ] 1.5 Include standalone-store build/smoke configuration in the frontend reference app while keeping the two-client happy path scoped to WebSockets.
+- [ ] 1.6 Keep reference application dependencies and source limited to the supported integration contract; document the boundary that excludes product-specific application behavior.
+- [ ] 1.7 Register a second, structurally distinct node type and enable the undo/redo action in the reference frontend as a minimal genericity check for the node-registration and plugin extension points, without expanding into a full node/plugin coverage matrix.
+
+## 2. Package-boundary validation
+
+- [ ] 2.1 Inventory publishable packages, documented browser/server entry points, peer dependencies, and supported standalone/WebSocket configurations to define the validation matrix.
+- [ ] 2.2 Add reusable helpers that build selected packages, create `npm pack` tarballs, and install them into cleaned isolated temporary consumer directories without workspace links.
+- [ ] 2.3 Configure the reference applications and minimal browser/backend smoke consumers to install packed local artifacts and explicitly import browser entry points and `@inditextech/weave-sdk/server`.
+- [ ] 2.4 Add type-check and production-build assertions for the isolated consumers, including failure reporting that identifies the package, entry point, and validation stage.
+- [ ] 2.5 Add targeted tests that demonstrate the tarball helper detects omitted published files, invalid exports, declarations, dependency metadata, and browser/server boundary failures.
+
+## 3. WebSocket collaboration integration
+
+- [ ] 3.1 Add Playwright and Chromium test infrastructure with deterministic frontend/backend startup, readiness checks, teardown, and failure diagnostics.
+- [ ] 3.2 Implement a two-independent-browser-context scenario that uses the reference-app rectangle controls or test hooks and asserts creation, remote rendering, attribute update, deletion, and convergence through the WebSocket service.
+- [ ] 3.3 Extend the rectangle scenario to disconnect and reconnect a client, then assert that it receives and renders current shared state.
+- [ ] 3.4 Ensure integration assertions use semantic model and UI state rather than required canvas screenshot pixel comparisons.
+- [ ] 3.5 Add a concurrent-edit scenario where both browser clients change the same shared attribute without waiting on each other, asserting both clients converge on the same deterministic state rather than asserting a specific intermediate ordering.
+
+## 4. Generator additions and starter validation
+
+- [ ] 4.1 Add direct frontend and backend generator tests with dependency installation disabled for output trees, renamed dotfiles, manifests, selected transport configuration, and invalid input errors.
+- [ ] 4.2 Organize the established reference-app source for generator reuse while keeping test harness code outside generated projects.
+- [ ] 4.3 Add the canonical Vite + React frontend option and canonical minimal Express + WebSocket backend option as new generator choices, alongside all existing templates (Next.js + WebSocket, Next.js + Azure Web PubSub, Express + WebSocket, Express + Azure Web PubSub), which remain available and unchanged; ensure generator prompts/CLI flags let a user select unambiguously between an existing template and the new canonical option where names could otherwise collide.
+- [ ] 4.4 Add generated-project matrix tests that create every supported standalone/WebSocket starter (existing and new canonical) in a temporary directory, install packed local artifacts, type-check, and production-build it.
+
+## 5. CI and release enforcement
+
+- [ ] 5.1 Add affected lint, type-check, build, and unit-test selection for relevant pull requests.
+- [ ] 5.2 Add path-selected, blocking tarball-consumer and Playwright collaboration jobs for changes to publishable packages, package metadata, generators, and reference consumers.
+- [ ] 5.3 Cache npm dependencies and reusable build artifacts; report the failed consumer, package, entry point, or transport configuration from distribution jobs.
+- [ ] 5.4 Add a nightly matrix for every supported standalone and WebSocket configuration and require the same matrix for release-candidate publication.
+- [ ] 5.5 Preserve Azure Web PubSub unit/contract coverage with controlled mocks and verify that normal distribution jobs require neither cloud credentials nor live Azure services.
+- [ ] 5.6 Add a Firefox browser-engine lane to the nightly collaboration matrix, keeping the PR-gating collaboration lane on Chromium only.
+
+## 6. Validation and rollout
+
+- [ ] 6.1 Run the full package tarball, reference-consumer, collaboration, generator, and transport matrix locally or in CI to establish a passing baseline.
+- [ ] 6.2 Measure and stabilize the new jobs, resolving nondeterministic startup, browser, or temporary-install failures with state-based synchronization and clear diagnostics.
+- [ ] 6.3 Enable the new PR gates as release-blocking checks and record the temporary job-disable rollback procedure without removing existing unit and package checks.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
- Add OpenSpec config, prompts, and skills for spec-driven proposals.
- Propose establish-consumer-test-strategy: canonical Vite+React and Express+WebSocket reference consumers to validate published npm artifacts, generator templates, and cross-client CRDT convergence