### PR TITLE
SonarCloud analysis fails: Java 17 no longer supported

### DIFF
--- a/.github/workflows/code-npm_node-sonarcloud-analysis.yml
+++ b/.github/workflows/code-npm_node-sonarcloud-analysis.yml
@@ -114,6 +114,12 @@ jobs:
           echo "app-name=$(jq -r '.name' code/package.json)" >> "$GITHUB_OUTPUT"
           echo "github-repository=$(echo $GITHUB_REPOSITORY | cut -d'/' -f2)" >> "$GITHUB_OUTPUT"
 
+      - name: SonarCloud / Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
       - name: SonarCloud / Check coverage file
         id: coverage-check
         working-directory: code


### PR DESCRIPTION
## What

Adds an `actions/setup-java` step (Temurin 21) before the SonarCloud scanner runs in `.github/workflows/code-npm_node-sonarcloud-analysis.yml`.

## Why

Every PR's `SonarCloud / Unit Tests` check currently fails with:

```
ERROR: The version of Java (17) used to run this analysis is deprecated, and SonarQube Cloud no longer supports it. Please upgrade to Java 21 or later.
```

`npx sonar-scanner` (unpinned) resolves to the legacy, unmaintained `sonar-scanner@3.1.0` npm package, which doesn't auto-provision a JRE — it runs analysis with whatever `java` is first on the runner's `PATH`, which is Java 17 on `ubuntu-24.04`. SonarQube Cloud dropped support for Java 17 analysis.

Closes #1140