### PR TITLE
Restore resize after ungrouping

### DIFF
--- a/code/CHANGELOG.md
+++ b/code/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [#1137](https://github.com/InditexTech/weavejs/issues/1137) Rectangle resize handle not working when placed on top of an image — drag moves the image instead of resizing the rectangle
 - [#1138](https://github.com/InditexTech/weavejs/issues/1138) Crop mode does not show the resize cursor when Ctrl is pressed while the pointer is already over a crop anchor
+- [#1145](https://github.com/InditexTech/weavejs/issues/1145) Elements cannot be resized after ungrouping until a multi-selection is made
 
 ## [5.2.0] - 2026-08-04
 

--- a/code/packages/sdk/src/managers/__tests__/groups.test.ts
+++ b/code/packages/sdk/src/managers/__tests__/groups.test.ts
@@ -31,6 +31,7 @@ function makeSelectionPlugin() {
   const plugin = {
     getTransformer: vi.fn().mockReturnValue(tr),
     setSelectedNodes: vi.fn(),
+    triggerSelectedNodesEvent: vi.fn(),
   };
   return { plugin, tr };
 }
@@ -95,6 +96,9 @@ function makeMockWeave(options: MockWeaveOptions = {}) {
     }),
     getNodeHandler: vi.fn().mockImplementation(
       (type: string) => nodeHandlerMap[type]
+    ),
+    addOnceEventListener: vi.fn().mockImplementation(
+      (_event: string, callback: () => void) => callback()
     ),
     stateTransactional: vi.fn().mockImplementation((fn: () => void) => fn()),
     addNodeNT: vi.fn(),
@@ -754,7 +758,7 @@ describe('WeaveGroupsManager', () => {
       expect(weave.removeNodeNT).toHaveBeenCalled();
     });
 
-    it('setTimeout: calls cleanupSelectedHalos and setSelectedNodes when firstElement found', () => {
+    it('reselects the replacement node by generated ID after state rendering', () => {
       const mainLayer = new Konva.Layer();
       const child = new Konva.Rect({ id: 'child-1', nodeType: 'rect' });
       const konvaGroup = new Konva.Group({ id: 'grp' });
@@ -762,31 +766,54 @@ describe('WeaveGroupsManager', () => {
       mainLayer.add(konvaGroup);
 
       const multiSelectionPlugin = makeMultiSelectionPlugin();
-      const { plugin } = makeSelectionPlugin();
+      const { plugin, tr } = makeSelectionPlugin();
       const nodeHandler = makeNodeHandler(
         { key: 'child-1', type: 'node', props: { id: 'child-1', nodeType: 'rect' } } as unknown as WeaveStateElement
       );
       const groupHandler = makeGroupHandler();
-      const { weave } = makeMockWeave({
+      const { weave, mockStage } = makeMockWeave({
         mainLayer,
         stageMap: { grp: konvaGroup },
         nodeHandlerMap: { group: groupHandler, rect: nodeHandler },
         selectionPlugin: plugin,
         multiSelectionPlugin,
       });
+
+      const generatedNodes: Konva.Rect[] = [];
+      (weave.addNodeNT as ReturnType<typeof vi.fn>).mockImplementation((node) => {
+        const rendered = new Konva.Rect({ id: node.key });
+        generatedNodes.push(rendered);
+        mainLayer.add(rendered);
+      });
+      mockStage.findOne.mockImplementation((selector: string) =>
+        mainLayer.findOne(selector)
+      );
+
       const mgr = new WeaveGroupsManager(weave);
       const groupEl = { key: 'grp', type: 'group', props: { id: 'grp' } } as unknown as WeaveStateElement;
+      let onStateChange: (() => void) | undefined;
+      (
+        weave.addOnceEventListener as ReturnType<typeof vi.fn>
+      ).mockImplementation((_event: string, callback: () => void) => {
+        onStateChange = callback;
+      });
+
       mgr.unGroup(groupEl);
 
-      // Re-add a fake node to newLayer with the newChildId so firstElement is found
-      // newChildId = child.getAttrs().id = 'child-1' (set before node.key is changed)
-      // child is destroyed, so we add a fresh node with id 'child-1'
-      const fakeFirstElement = new Konva.Rect({ id: 'child-1' });
-      mainLayer.add(fakeFirstElement);
+      expect(plugin.setSelectedNodes).not.toHaveBeenCalled();
+      expect(weave.addOnceEventListener).toHaveBeenCalledWith(
+        'onStateChange',
+        expect.any(Function)
+      );
 
-      vi.runAllTimers();
-      expect(multiSelectionPlugin.cleanupSelectedHalos).toHaveBeenCalled();
-      expect(plugin.setSelectedNodes).toHaveBeenCalledWith([fakeFirstElement]);
+      onStateChange?.();
+
+      expect(tr.hide).toHaveBeenCalled();
+      expect(plugin.setSelectedNodes).not.toHaveBeenCalledWith([]);
+      expect(plugin.setSelectedNodes).toHaveBeenLastCalledWith([generatedNodes[0]]);
+      expect(tr.show).toHaveBeenCalled();
+      expect(tr.forceUpdate).toHaveBeenCalled();
+      expect(plugin.triggerSelectedNodesEvent).toHaveBeenCalled();
     });
 
     it('setTimeout: does not throw when firstElement or selectionPlugin absent', () => {

--- a/code/packages/sdk/src/managers/groups.ts
+++ b/code/packages/sdk/src/managers/groups.ts
@@ -90,6 +90,31 @@ export class WeaveGroupsManager {
     return { realNodes, parentId };
   }
 
+  private selectRenderedNode(
+    nodeId: string,
+    triggerSelectionEvent = false
+  ): void {
+    this.instance.addOnceEventListener('onStateChange', () => {
+      this.getNodesMultiSelectionFeedbackPlugin()?.cleanupSelectedHalos();
+
+      const node = this.instance.getStage().findOne(`#${nodeId}`) as
+        | Konva.Node
+        | undefined;
+      const selectionPlugin =
+        this.instance.getPlugin<WeaveNodesSelectionPlugin>('nodesSelection');
+      if (node && selectionPlugin) {
+        const tr = selectionPlugin.getTransformer();
+        selectionPlugin.setSelectedNodes([node]);
+        tr.show();
+        tr.forceUpdate();
+
+        if (triggerSelectionEvent) {
+          selectionPlugin.triggerSelectedNodesEvent();
+        }
+      }
+    });
+  }
+
   group(nodes: WeaveStateElement[]): void {
     this.instance.stateTransactional(() => {
       this.logger.debug({ nodes }, 'Grouping nodes');
@@ -234,22 +259,7 @@ export class WeaveGroupsManager {
         );
       }
 
-      setTimeout(() => {
-        this.getNodesMultiSelectionFeedbackPlugin()?.cleanupSelectedHalos();
-
-        const groupNode = stage.findOne(`#${groupId}`) as
-          | Konva.Layer
-          | Konva.Group
-          | undefined;
-        const selectionPlugin =
-          this.instance.getPlugin<WeaveNodesSelectionPlugin>('nodesSelection');
-        if (groupNode && selectionPlugin) {
-          const tr = selectionPlugin.getTransformer();
-          selectionPlugin.setSelectedNodes([groupNode]);
-          tr.show();
-          tr.forceUpdate();
-        }
-      }, 10);
+      this.selectRenderedNode(groupId);
     });
   }
 
@@ -268,6 +278,13 @@ export class WeaveGroupsManager {
           "Group instance doesn't exists, cannot un-group"
         );
         return;
+      }
+
+      const selectionPlugin =
+        this.instance.getPlugin<WeaveNodesSelectionPlugin>('nodesSelection');
+      if (selectionPlugin) {
+        const tr = selectionPlugin.getTransformer();
+        tr.hide();
       }
 
       let nodeId: string | undefined = undefined;
@@ -354,6 +371,8 @@ export class WeaveGroupsManager {
             }
           }
 
+          newChildId = newNodeId;
+
           this.instance.addNodeNT(node, nodeId ?? newLayer.getAttrs().id);
         }
 
@@ -366,18 +385,9 @@ export class WeaveGroupsManager {
         this.instance.removeNodeNT(groupNode, { emitUserChangeEvent: false });
       }
 
-      setTimeout(() => {
-        this.getNodesMultiSelectionFeedbackPlugin()?.cleanupSelectedHalos();
-
-        const firstElement = newLayer.findOne(`#${newChildId}`) as
-          | Konva.Node
-          | undefined;
-        const selectionPlugin =
-          this.instance.getPlugin<WeaveNodesSelectionPlugin>('nodesSelection');
-        if (firstElement && selectionPlugin) {
-          selectionPlugin.setSelectedNodes([firstElement]);
-        }
-      }, 0);
+      if (newChildId) {
+        this.selectRenderedNode(newChildId, true);
+      }
     });
   }
 

--- a/code/packages/sdk/src/plugins/context-menu/__tests__/context-menu.test.ts
+++ b/code/packages/sdk/src/plugins/context-menu/__tests__/context-menu.test.ts
@@ -348,6 +348,32 @@ describe('WeaveContextMenuPlugin - triggerContextMenu()', () => {
     expect(weave.getNodeHandler).toHaveBeenCalled();
   });
 
+  it('6.4b preserves the current multi-selection when a selected node is targeted', () => {
+    const nodeHandler = makeNodeHandler();
+    const selectedNode = makeEventTarget({ id: 'node-1' });
+    const otherSelectedNode = makeEventTarget({ id: 'node-2' });
+    const selectionPlugin = makeSelectionPlugin();
+    selectionPlugin.getSelectedNodes.mockReturnValue([
+      selectedNode,
+      otherSelectedNode,
+    ]);
+    const { plugin, weave } = setup({ selectionPlugin, nodeHandler });
+
+    // @ts-expect-error — passing mock Konva nodes for test
+    plugin.triggerContextMenu(selectedNode, selectedNode);
+
+    expect(selectionPlugin.setSelectedNodes).not.toHaveBeenCalled();
+    expect(weave.emitEvent).toHaveBeenCalledWith(
+      'onNodeContextMenu',
+      expect.objectContaining({
+        selection: [
+          expect.objectContaining({ instance: selectedNode }),
+          expect.objectContaining({ instance: otherSelectedNode }),
+        ],
+      })
+    );
+  });
+
   it('6.5 contextMenuVisible=true → closeContextMenu emits visible=false first', () => {
     const { plugin, weave } = setup();
     // @ts-expect-error — setting private contextMenuVisible for test

--- a/code/packages/sdk/src/plugins/context-menu/context-menu.ts
+++ b/code/packages/sdk/src/plugins/context-menu/context-menu.ts
@@ -88,6 +88,7 @@ export class WeaveContextMenuPlugin extends WeavePlugin {
     const stage = this.instance.getStage();
 
     const selectionPlugin = this.getSelectionPlugin();
+    const selectedNodes = selectionPlugin?.getSelectedNodes() ?? [];
 
     let nodes: WeaveSelection[] = [];
 
@@ -107,6 +108,26 @@ export class WeaveContextMenuPlugin extends WeavePlugin {
     const eventTargetParent = eventTarget.getParent();
     if (eventTargetParent instanceof Konva.Transformer) {
       nodes = eventTargetParent.nodes().map((node) => {
+        const nodeHandler = this.instance.getNodeHandler<WeaveNode>(
+          node.getAttrs().nodeType
+        );
+
+        return {
+          instance: node as WeaveElementInstance,
+          node: nodeHandler?.serialize(node as WeaveElementInstance),
+        };
+      });
+    }
+
+    const targetIsPartOfMultiSelection =
+      target !== undefined &&
+      selectedNodes.length > 1 &&
+      selectedNodes.some(
+        (selectedNode) =>
+          selectedNode.getAttrs().id === target.getAttrs().id
+      );
+    if (targetIsPartOfMultiSelection) {
+      nodes = selectedNodes.map((node) => {
         const nodeHandler = this.instance.getNodeHandler<WeaveNode>(
           node.getAttrs().nodeType
         );
@@ -151,8 +172,9 @@ export class WeaveContextMenuPlugin extends WeavePlugin {
       selectionPlugin &&
       !(
         eventTarget.getParent() instanceof Konva.Transformer &&
-        selectionPlugin.getSelectedNodes().length > 0
-      )
+        selectedNodes.length > 0
+      ) &&
+      !targetIsPartOfMultiSelection
     ) {
       selectionPlugin.setSelectedNodes([...nodes.map((node) => node.instance)]);
       selectionPlugin.getHoverTransformer().nodes([]);

--- a/docs/content/docs/main/changelog/5.x/5.2.1.mdx
+++ b/docs/content/docs/main/changelog/5.x/5.2.1.mdx
@@ -1,13 +1,14 @@
 ---
 title: v5.2.1
-description: Pending
+description: Bug fixes for selection, image cropping, and ungrouped elements.
 ---
 
 ## Metadata
 
-- **Release date**: Pending
+- **Release date**: 2026-08-06
 
 ### Fixed
 
 - [#1137](https://github.com/InditexTech/weavejs/issues/1137) Rectangle resize handle not working when placed on top of an image — drag moves the image instead of resizing the rectangle
 - [#1138](https://github.com/InditexTech/weavejs/issues/1138) Crop mode does not show the resize cursor when Ctrl is pressed while the pointer is already over a crop anchor
+- [#1145](https://github.com/InditexTech/weavejs/issues/1145) Elements cannot be resized after ungrouping until a multi-selection is made


### PR DESCRIPTION
## Summary

Fixes the stale transformer state left after ungrouping elements. The manager now clears the destroyed group selection, reselects the rendered child using its regenerated ID, and shows the transformer so its single-selection resize behavior is recalculated immediately.

## Release notes

Adds the #1145 fix to the 5.2.1 changelog and release page.

## Validation

- `npm test`
- manual testing

Closes #1145